### PR TITLE
add context timeout

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,6 +27,8 @@ services:
     volumes:
     - ".:/app"
     - "pkg:/go/pkg/"
+    # extra_hosts:
+    # - "db:192.168.55.1"
 
 volumes:
   pkg:


### PR DESCRIPTION
- Move set up into their own functions and clean up some of the order.
- Adds context timeout to database calls.  

This should let the metric status update sooner if a database hostname resolves, but the IP address is not reachable.  The OS/Dialer timeouts delay PING return by 5m30s.

Fixes #7